### PR TITLE
Fix settings serialization for Pydantic v2

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -60,7 +61,12 @@ def load_settings() -> Settings:
 
 def save_settings(settings: Settings) -> None:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    CONFIG_PATH.write_text(settings.model_dump_json(indent=2, ensure_ascii=False), encoding="utf-8")
+    serialized = json.dumps(
+        settings.model_dump(),
+        ensure_ascii=False,
+        indent=2,
+    )
+    CONFIG_PATH.write_text(serialized, encoding="utf-8")
 
 
 def update_settings(partial: Dict[str, Any]) -> Settings:


### PR DESCRIPTION
## Summary
- serialize configuration data with `json.dumps` so we can disable ASCII escaping while remaining compatible with Pydantic v2

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cab7ce382c8322a38f6de728ead7bf