### PR TITLE
Streamline setup flow and improve DIP filters

### DIFF
--- a/backend/app/bundestag.py
+++ b/backend/app/bundestag.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Set, Tuple
 
 import httpx
+
+from datetime import datetime, timedelta
 
 from .config import load_settings
 
@@ -43,3 +45,142 @@ async def fetch_dataset(dataset: str, params: Dict[str, Any]) -> Dict[str, Any]:
 async def fetch_document(dataset: str, document_id: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
     client = BundestagClient()
     return await client.get_document(dataset, document_id, params)
+
+
+_METADATA_CACHE: Tuple[datetime, Dict[str, Any]] | None = None
+_METADATA_TTL = timedelta(hours=6)
+
+
+async def _collect_vorgang_metadata(client: BundestagClient) -> Dict[str, Set[Any]]:
+    cursor: str | None = None
+    seen_cursor: str | None = None
+    iterations = 0
+    wahlperioden: Set[int] = set()
+    vorgangstypen: Set[str] = set()
+    initiativen: Set[str] = set()
+
+    while iterations < 12:
+        params: Dict[str, Any] = {}
+        if cursor:
+            params["cursor"] = cursor
+        data = await client.list_documents("vorgang", params)
+        documents = data.get("documents", [])
+        for document in documents:
+            wp = document.get("wahlperiode")
+            if isinstance(wp, list):
+                for entry in wp:
+                    if isinstance(entry, int):
+                        wahlperioden.add(entry)
+                    elif isinstance(entry, str) and entry.isdigit():
+                        wahlperioden.add(int(entry))
+            elif isinstance(wp, int):
+                wahlperioden.add(wp)
+            elif isinstance(wp, str) and wp.isdigit():
+                wahlperioden.add(int(wp))
+
+            vt = document.get("vorgangstyp")
+            if isinstance(vt, str) and vt.strip():
+                vorgangstypen.add(vt.strip())
+
+            initiative_values = document.get("initiative")
+            if isinstance(initiative_values, list):
+                for initiative in initiative_values:
+                    if isinstance(initiative, str) and initiative.strip():
+                        initiativen.add(initiative.strip())
+
+        next_cursor = data.get("cursor")
+        if not next_cursor or next_cursor == seen_cursor:
+            break
+        seen_cursor = cursor
+        cursor = next_cursor
+        iterations += 1
+
+        if len(wahlperioden) >= 25 and len(vorgangstypen) >= 150 and len(initiativen) >= 300:
+            break
+
+    return {
+        "wahlperioden": wahlperioden,
+        "vorgangstypen": vorgangstypen,
+        "initiativen": initiativen,
+    }
+
+
+async def _collect_drucksache_metadata(client: BundestagClient) -> Set[str]:
+    cursor: str | None = None
+    seen_cursor: str | None = None
+    drucksachetypen: Set[str] = set()
+    iterations = 0
+
+    while iterations < 6:
+        params: Dict[str, Any] = {}
+        if cursor:
+            params["cursor"] = cursor
+        data = await client.list_documents("drucksache", params)
+        for document in data.get("documents", []):
+            typ = document.get("drucksachetyp")
+            if isinstance(typ, str) and typ.strip():
+                drucksachetypen.add(typ.strip())
+
+        next_cursor = data.get("cursor")
+        if not next_cursor or next_cursor == seen_cursor:
+            break
+        seen_cursor = cursor
+        cursor = next_cursor
+        iterations += 1
+
+        if len(drucksachetypen) >= 80:
+            break
+
+    return drucksachetypen
+
+
+async def fetch_metadata_options() -> Dict[str, Any]:
+    global _METADATA_CACHE
+    now = datetime.utcnow()
+    if _METADATA_CACHE and now - _METADATA_CACHE[0] < _METADATA_TTL:
+        return _METADATA_CACHE[1]
+
+    client = BundestagClient()
+    vorgang_metadata = await _collect_vorgang_metadata(client)
+    drucksachetypen = await _collect_drucksache_metadata(client)
+
+    payload: Dict[str, Any] = {
+        "wahlperioden": sorted(vorgang_metadata["wahlperioden"]),
+        "vorgangstypen": sorted(vorgang_metadata["vorgangstypen"]),
+        "initiativen": sorted(vorgang_metadata["initiativen"]),
+        "drucksachetypen": sorted(drucksachetypen),
+        "dokumentarten": ["Drucksache", "Plenarprotokoll"],
+        "zuordnungen": ["BT", "BR", "BV", "EK"],
+    }
+
+    _METADATA_CACHE = (now, payload)
+    return payload
+
+
+async def search_persons(query: str, cursor: str | None = None) -> Dict[str, Any]:
+    client = BundestagClient()
+    params: Dict[str, Any] = {}
+    if query.strip():
+        params["f.person"] = [query.strip()]
+    if cursor:
+        params["cursor"] = cursor
+
+    data = await client.list_documents("person", params)
+    options: List[Dict[str, Any]] = []
+    for document in data.get("documents", []):
+        entry = {
+            "id": document.get("id"),
+            "title": document.get("titel") or " ".join(
+                filter(None, [document.get("vorname"), document.get("nachname")])
+            ).strip(),
+            "fraktion": document.get("fraktion"),
+            "funktion": document.get("funktion"),
+            "wahlperioden": document.get("wahlperiode", []),
+        }
+        options.append(entry)
+
+    return {
+        "options": options,
+        "cursor": data.get("cursor"),
+        "numFound": data.get("numFound"),
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,12 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from . import config
-from .bundestag import fetch_dataset, fetch_document
+from .bundestag import (
+    fetch_dataset,
+    fetch_document,
+    fetch_metadata_options,
+    search_persons,
+)
 from .gemini import generate_with_gemini
 from .schemas import ConfigUpdate, DatasetRequest, GeminiTaskRequest
 
@@ -115,4 +120,20 @@ async def gemini_task(request: GeminiTaskRequest) -> Dict[str, Any]:
     except RuntimeError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@app.get("/api/bundestag/options")
+async def bundestag_options() -> Dict[str, Any]:
+    try:
+        return await fetch_metadata_options()
+    except Exception as exc:  # pragma: no cover - API Feedback
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@app.get("/api/bundestag/persons")
+async def bundestag_persons(q: str = "", cursor: str | None = None) -> Dict[str, Any]:
+    try:
+        return await search_persons(q, cursor)
+    except Exception as exc:  # pragma: no cover - API Feedback
         raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/frontend/src/api/bundestag.js
+++ b/frontend/src/api/bundestag.js
@@ -9,3 +9,18 @@ export const fetchDocument = async ({ dataset, documentId }) => {
   const { data } = await api.get(`/bundestag/${dataset}/${documentId}`);
   return data;
 };
+
+export const fetchMetadataOptions = async () => {
+  const { data } = await api.get('/bundestag/options');
+  return data;
+};
+
+export const searchPersons = async ({ query, cursor }) => {
+  const { data } = await api.get('/bundestag/persons', {
+    params: {
+      q: query ?? '',
+      cursor: cursor ?? undefined,
+    },
+  });
+  return data;
+};

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+VENV_PATH="$ROOT_DIR/.venv"
+
+info() { echo -e "\033[1;34m[i]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[!]\033[0m $*"; }
+error() { echo -e "\033[1;31m[x]\033[0m $*"; }
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    return 1
+  fi
+}
+
+ensure_package() {
+  local pkg="$1"
+  if dpkg -s "$pkg" >/dev/null 2>&1; then
+    return 0
+  fi
+  info "Installiere Paket $pkg (benötigt sudo)"
+  sudo apt-get update
+  sudo apt-get install -y "$pkg"
+}
+
+info "Starte Bootstrap für Tag2"
+
+# Prüfe Python und venv-Unterstützung
+if ! command -v python3 >/dev/null 2>&1; then
+  error "python3 nicht gefunden. Bitte installiere Python 3.12 oder neuer."
+  exit 1
+fi
+
+if ! python3 -m venv --help >/dev/null 2>&1; then
+  warn "python3-venv ist nicht installiert – wird nachinstalliert."
+  ensure_package "python3.12-venv"
+  ensure_package "python3-pip"
+fi
+
+# Stelle Node.js >= 20 sicher
+if require_command node; then
+  NODE_VERSION="$(node -v | sed 's/v//')"
+  NODE_MAJOR="${NODE_VERSION%%.*}"
+else
+  NODE_MAJOR=0
+fi
+
+if [[ "$NODE_MAJOR" -lt 20 ]]; then
+  warn "Node.js 20.x wird benötigt. NodeSource-Repository wird eingebunden (sudo erforderlich)."
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+else
+  info "Node.js $(node -v) erfüllt die Anforderungen."
+fi
+
+# Virtuelle Umgebung vorbereiten
+if [[ ! -d "$VENV_PATH" ]]; then
+  info "Erstelle virtuelle Python-Umgebung in $VENV_PATH"
+  python3 -m venv "$VENV_PATH"
+else
+  info "Virtuelle Umgebung bereits vorhanden."
+fi
+
+# Aktivieren und Abhängigkeiten installieren
+# shellcheck source=/dev/null
+source "$VENV_PATH/bin/activate"
+
+info "Aktualisiere pip"
+pip install --upgrade pip
+
+info "Installiere Backend-Abhängigkeiten"
+pip install -r "$ROOT_DIR/backend/requirements.txt"
+
+info "Installiere Frontend-Abhängigkeiten"
+(cd "$ROOT_DIR/frontend" && npm install)
+
+info "Bootstrap abgeschlossen. Aktiviere zukünftig die Umgebung mit: source $VENV_PATH/bin/activate"

--- a/scripts/devserver.py
+++ b/scripts/devserver.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Starte Backend (uvicorn) und Frontend (Vite) in einem Prozess."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+BACKEND_DIR = ROOT_DIR / "backend"
+FRONTEND_DIR = ROOT_DIR / "frontend"
+
+
+async def _stream_output(prefix: str, stream: asyncio.StreamReader) -> None:
+    while True:
+        line = await stream.readline()
+        if not line:
+            break
+        text = line.decode(errors="replace").rstrip()
+        print(f"[{prefix}] {text}")
+
+
+async def _create_process(command: list[str], cwd: Path, name: str) -> asyncio.subprocess.Process:
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        cwd=str(cwd),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    assert process.stdout is not None
+    asyncio.create_task(_stream_output(name, process.stdout))
+    return process
+
+
+async def main() -> int:
+    backend_cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "app.main:app",
+        "--reload",
+        "--port",
+        os.environ.get("TAG2_BACKEND_PORT", "8000"),
+    ]
+    frontend_cmd = [
+        "npm",
+        "run",
+        "dev",
+        "--",
+        "--host",
+        os.environ.get("TAG2_FRONTEND_HOST", "0.0.0.0"),
+        "--port",
+        os.environ.get("TAG2_FRONTEND_PORT", "5173"),
+    ]
+
+    backend_process = await _create_process(backend_cmd, BACKEND_DIR, "backend")
+    frontend_process = await _create_process(frontend_cmd, FRONTEND_DIR, "frontend")
+
+    shutdown_event = asyncio.Event()
+
+    def _request_shutdown() -> None:
+        shutdown_event.set()
+
+    loop = asyncio.get_event_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _request_shutdown)
+        except NotImplementedError:  # pragma: no cover - Windows fallback
+            signal.signal(sig, lambda *_: _request_shutdown())
+
+    async def wait_for_exit() -> None:
+        tasks = [asyncio.create_task(proc.wait()) for proc in (backend_process, frontend_process)]
+        done, pending = await asyncio.wait(
+            [*tasks, asyncio.create_task(shutdown_event.wait())],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        for task in pending:
+            task.cancel()
+
+        shutdown_event.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    await wait_for_exit()
+
+    for process, label in ((backend_process, "backend"), (frontend_process, "frontend")):
+        if process.returncode is None:
+            process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                process.kill()
+        if process.returncode not in (0, None):
+            print(f"[{label}] Prozess beendet sich mit Status {process.returncode}")
+
+    backend_code = backend_process.returncode or 0
+    frontend_code = frontend_process.returncode or 0
+    return backend_code or frontend_code
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = asyncio.run(main())
+    except KeyboardInterrupt:  # pragma: no cover - CLI Komfort
+        exit_code = 0
+    sys.exit(exit_code)


### PR DESCRIPTION
## Summary
- add bootstrap and devserver helper scripts so Tag2 can be installed and started with one command
- expose metadata and person lookup endpoints and wire the UI to dropdown filters, live person search and API-key gating
- refresh the README with the simplified workflow and configuration guidance

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab9df016c832299919d407c56b0aa